### PR TITLE
在删除之后，不能够正确读取binlog的最大值

### DIFF
--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -241,9 +241,7 @@ int BinlogQueue::find_last(Binlog *log) const{
 	if(!it->Valid()){
 		// Iterator::prev requires Valid, so we seek to last
 		it->SeekToLast();
-	}
-	// UINT64_MAX is not used
-	if(it->Valid()){
+	}else{
 		it->Prev();
 	}
 	if(it->Valid()){


### PR DESCRIPTION
删除一个Key之后，通过上述方法，获得最大值仍然是之前的最大值，修改上面的代码之后，一切正常了。
