### PR TITLE
bug fix

### DIFF
--- a/api/go/ssdb/ssdb.go
+++ b/api/go/ssdb/ssdb.go
@@ -40,7 +40,7 @@ func (c *Client) Set(key string, val string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(resp) == 1 && resp[0] == "ok" {
+	if len(resp) == 2 && resp[0] == "ok" {
 		return true, nil
 	}
 	return nil, fmt.Errorf("bad response")


### PR DESCRIPTION
The successful response is [ok 1]. So 'len(resp)' should be '2' instead of '1'.
