### PR TITLE
change: 不再写死用g++编译,这样就可以按需要使用clang++啦

### DIFF
--- a/api/cpp/Makefile
+++ b/api/cpp/Makefile
@@ -1,11 +1,11 @@
 include ../../build_config.mk
 
 all: lib
-	g++ -o demo demo.cpp libssdb.a
-	g++ -o hello-ssdb hello-ssdb.cpp libssdb.a
+	${CXX} -o demo demo.cpp libssdb.a
+	${CXX} -o hello-ssdb hello-ssdb.cpp libssdb.a
 
 lib: SSDB.h SSDB_impl.h SSDB_impl.cpp
-	g++ -I../../src ${CFLAGS} -c SSDB_impl.cpp
+	${CXX} -I../../src ${CFLAGS} -c SSDB_impl.cpp
 	ar -cru libssdb.a\
 		SSDB_impl.o\
 		../../src/util/bytes.o\

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,51 +8,51 @@ EXES = ../ssdb-server
 
 
 all: ssdb.h ${OBJS} ssdb-server.o
-	g++ -o ../ssdb-server ssdb-server.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
+	${CXX} -o ../ssdb-server ssdb-server.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
 
 ssdb-server.o: ssdb-server.cpp
-	g++ ${CFLAGS} -c ssdb-server.cpp
+	${CXX} ${CFLAGS} -c ssdb-server.cpp
 
 objs: ssdb.h ${OBJS}
 
 ssdb.o: ssdb.h ssdb.cpp
-	g++ ${CFLAGS} -c ssdb.cpp
+	${CXX} ${CFLAGS} -c ssdb.cpp
 
 iterator.o: ssdb.h iterator.h iterator.cpp
-	g++ ${CFLAGS} -c iterator.cpp
+	${CXX} ${CFLAGS} -c iterator.cpp
 
 t_kv.o: ssdb.h t_kv.h t_kv.cpp
-	g++ ${CFLAGS} -c t_kv.cpp
+	${CXX} ${CFLAGS} -c t_kv.cpp
 
 t_hash.o: ssdb.h t_hash.h t_hash.cpp
-	g++ ${CFLAGS} -c t_hash.cpp
+	${CXX} ${CFLAGS} -c t_hash.cpp
 
 t_zset.o: ssdb.h t_zset.h t_zset.cpp
-	g++ ${CFLAGS} -c t_zset.cpp
+	${CXX} ${CFLAGS} -c t_zset.cpp
 
 t_queue.o: ssdb.h t_queue.h t_queue.cpp
-	g++ ${CFLAGS} -c t_queue.cpp
+	${CXX} ${CFLAGS} -c t_queue.cpp
 
 link.o: ssdb.h link.h link.cpp link_redis.h link_redis.cpp
-	g++ ${CFLAGS} -c link.cpp
+	${CXX} ${CFLAGS} -c link.cpp
 
 binlog.o: ssdb.h binlog.h binlog.cpp
-	g++ ${CFLAGS} -c binlog.cpp
+	${CXX} ${CFLAGS} -c binlog.cpp
 
 slave.o: ssdb.h slave.h slave.cpp
-	g++ ${CFLAGS} -c slave.cpp
+	${CXX} ${CFLAGS} -c slave.cpp
 
 serv.o: ssdb.h serv.h serv.cpp proc_kv.cpp proc_hash.cpp proc_zset.cpp proc_queue.cpp
-	g++ ${CFLAGS} -c serv.cpp
+	${CXX} ${CFLAGS} -c serv.cpp
 
 backend_dump.o: ssdb.h backend_dump.h backend_dump.cpp
-	g++ ${CFLAGS} -c backend_dump.cpp
+	${CXX} ${CFLAGS} -c backend_dump.cpp
 
 backend_sync.o: ssdb.h backend_sync.h backend_sync.cpp
-	g++ ${CFLAGS} -c backend_sync.cpp
+	${CXX} ${CFLAGS} -c backend_sync.cpp
 
 ttl.o: ssdb.h ttl.h ttl.cpp
-	g++ ${CFLAGS} -c ttl.cpp
+	${CXX} ${CFLAGS} -c ttl.cpp
 
 clean:
 	rm -f ${EXES} *.o *.exe

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -6,23 +6,23 @@ EXES =
 all: ${OBJS}
 
 log.o: log.h log.cpp
-	g++ ${CFLAGS} -c log.cpp
+	${CXX} ${CFLAGS} -c log.cpp
 
 config.o: config.h config.cpp
-	g++ ${CFLAGS} -c config.cpp
+	${CXX} ${CFLAGS} -c config.cpp
 
 fde.o: fde.h fde.cpp fde_select.cpp fde_epoll.cpp
-	g++ ${CFLAGS} -c fde.cpp
+	${CXX} ${CFLAGS} -c fde.cpp
 
 bytes.o: bytes.h bytes.cpp
-	g++ ${CFLAGS} -c bytes.cpp
+	${CXX} ${CFLAGS} -c bytes.cpp
 
 sorted_set.o: sorted_set.h sorted_set.cpp
-	g++ ${CFLAGS} -c sorted_set.cpp
+	${CXX} ${CFLAGS} -c sorted_set.cpp
 
 
 test: sorted_set.o log.o
-	g++ -o test_sorted_set ${CFLAGS} sorted_set.o log.o test_sorted_set.cpp
+	${CXX} -o test_sorted_set ${CFLAGS} sorted_set.o log.o test_sorted_set.cpp
 	
 
 clean:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,19 +5,19 @@ CFLAGS += -I../src
 EXES = ssdb-bench ssdb-dump ssdb-repair leveldb-import
 
 all: ssdb-bench.o ssdb-dump.o ssdb-repair.o leveldb-import.o
-	g++ -o ssdb-bench ssdb-bench.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
-	g++ -o ssdb-dump ssdb-dump.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
-	g++ -o ssdb-repair ssdb-repair.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
-	g++ -o leveldb-import leveldb-import.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
+	${CXX} -o ssdb-bench ssdb-bench.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
+	${CXX} -o ssdb-dump ssdb-dump.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
+	${CXX} -o ssdb-repair ssdb-repair.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
+	${CXX} -o leveldb-import leveldb-import.o ${OBJS} ${UTIL_OBJS} ${CLIBS}
 
 ssdb-bench.o: ssdb-bench.cpp
-	g++ ${CFLAGS} -c ssdb-bench.cpp
+	${CXX} ${CFLAGS} -c ssdb-bench.cpp
 ssdb-dump.o: ssdb-dump.cpp
-	g++ ${CFLAGS} -c ssdb-dump.cpp
+	${CXX} ${CFLAGS} -c ssdb-dump.cpp
 ssdb-repair.o: ssdb-repair.cpp
-	g++ ${CFLAGS} -c ssdb-repair.cpp
+	${CXX} ${CFLAGS} -c ssdb-repair.cpp
 leveldb-import.o: leveldb-import.cpp
-	g++ ${CFLAGS} -c leveldb-import.cpp
+	${CXX} ${CFLAGS} -c leveldb-import.cpp
 
 clean:
 	rm -f *.exe *.exe.stackdump *.o ${EXES}


### PR DESCRIPTION
这样写话,既不影响原有的编译,又支持下面的语句进行编译

```
CC=clang CXX=clang++ make
```
