### PR TITLE
qpush应该返回插入后的长度

### DIFF
--- a/src/proc_queue.cpp
+++ b/src/proc_queue.cpp
@@ -70,7 +70,7 @@ int proc_qpush_func(Server *serv, Link *link, const Request &req, Response *resp
 		if(ret == -1){
 			resp->push_back("error");
 		}else{
-			resp->push_back("ok");
+			proc_qsize(serv, link, req, resp); // resp as "qsize"
 		}
 	}
 	return 0;


### PR DESCRIPTION
qpush命令只响应个ok,没有包含队列的长度,结果,还得再查一下队列长度,多费劲啊
