### PR TITLE
Add speed limit for sync

### DIFF
--- a/src/backend_sync.cpp
+++ b/src/backend_sync.cpp
@@ -100,9 +100,13 @@ void* BackendSync::_run_thread(void *arg){
 			idle = 0;
 		}
 
+		float data_size_mb = link->output->size() / 1024.0 / 1024.0;
 		if(link->flush() == -1){
 			log_info("%s:%d fd: %d, send error: %s", link->remote_ip, link->remote_port, link->fd(), strerror(errno));
 			break;
+		}
+		if(ssdb->get_sync_speed() > 0){
+			usleep((data_size_mb / ssdb->get_sync_speed()) * 1000 * 1000);
 		}
 	}
 

--- a/src/ssdb.cpp
+++ b/src/ssdb.cpp
@@ -9,7 +9,7 @@
 #include "t_hash.h"
 #include "t_zset.h"
 
-SSDB::SSDB(){
+SSDB::SSDB(): sync_speed_(0){
 	db = NULL;
 	meta_db = NULL;
 	binlogs = NULL;
@@ -114,6 +114,8 @@ SSDB* SSDB::open(const Config &conf, const std::string &base_dir){
 	{ // slaves
 		const Config *repl_conf = conf.get("replication");
 		if(repl_conf != NULL){
+			ssdb->sync_speed_ = repl_conf->get_num("sync_speed");
+			log_info("sync_speed      : %d MB/s", ssdb->sync_speed_);
 			std::vector<Config *> children = repl_conf->children;
 			for(std::vector<Config *>::iterator it = children.begin(); it != children.end(); it++){
 				Config *c = *it;

--- a/src/ssdb.h
+++ b/src/ssdb.h
@@ -24,6 +24,7 @@ private:
 	leveldb::DB* db;
 	leveldb::DB* meta_db;
 	leveldb::Options options;
+	int sync_speed_;
 
 	std::vector<Slave *> slaves;
 	
@@ -42,6 +43,7 @@ public:
 	std::vector<std::string> info() const;
 	void compact() const;
 	int key_range(std::vector<std::string> *keys) const;
+	int get_sync_speed() const { return sync_speed_; }
 
 	/* raw operates */
 

--- a/ssdb.conf
+++ b/ssdb.conf
@@ -18,6 +18,8 @@ server:
 
 replication:
 	binlog: yes
+	# Limit sync speed to 30 MB/s
+	sync_speed: 30
 	slaveof:
 		# to identify a master even if it moved(ip, port changed)
 		# if set to empty or not defined, ip:port will be used.


### PR DESCRIPTION
SSDB副本恢复时，主从同步会打满带宽，影响正常请求。这里增加了带宽限制
