### PR TITLE
Update SSDB.js

### DIFF
--- a/api/nodejs/SSDB.js
+++ b/api/nodejs/SSDB.js
@@ -29,7 +29,7 @@ exports.connect = function(host, port, timeout, listener){
 			listener('connect_failed', e);
 		}else{
 			var callback = callbacks.shift();
-			callback(['error']);
+			if(callback)callback(['error']);
 		}
 	});
 	sock.connect(port, host, function(){


### PR DESCRIPTION
fix bug: exception when callback is null.

```
        callback(['error']);
        ^
```

TypeError: undefined is not a function
    at Socket.<anonymous> (SSDB.js:32:13)
    at Socket.EventEmitter.emit (events.js:95:17)
    at net.js:440:14
    at process._tickCallback (node.js:415:13)
