### PR TITLE
更改目录结构更贴近nginx目录组织

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ install:
 	mkdir -p ${PREFIX}/var_slave
 	# add by stefan_bo
 	mkdir -p ${PREFIX}/bin
-    	mkdir -p ${PREFIX}/sbin
-    	mkdir -p ${PREFIX}/conf
+	mkdir -p ${PREFIX}/sbin
+	mkdir -p ${PREFIX}/conf
 	cp ssdb-server ${PREFIX}/sbin
 	cp ssdb.conf ssdb_slave.conf ${PREFIX}/conf
 	cp -r api ${PREFIX}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ install:
 	mkdir -p ${PREFIX}/deps
 	mkdir -p ${PREFIX}/var
 	mkdir -p ${PREFIX}/var_slave
+	# add by stefan_bo
 	mkdir -p ${PREFIX}/bin
     mkdir -p ${PREFIX}/sbin
     mkdir -p ${PREFIX}/conf

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,20 @@ install:
 	mkdir -p ${PREFIX}/deps
 	mkdir -p ${PREFIX}/var
 	mkdir -p ${PREFIX}/var_slave
-	cp ssdb-server ssdb.conf ssdb_slave.conf ${PREFIX}
+	mkdir -p ${PREFIX}/bin
+    mkdir -p ${PREFIX}/sbin
+    mkdir -p ${PREFIX}/conf
+	cp ssdb-server ${PREFIX}/sbin
+	cp ssdb.conf ssdb_slave.conf ${PREFIX}/conf
 	cp -r api ${PREFIX}
 	cp -r \
 		tools/ssdb-bench tools/ssdb-cli \
 		tools/ssdb-cli.cpy tools/ssdb-dump \
 		tools/ssdb-repair \
 		tools/ssdb-ins.sh tools/unittest.php \
-		${PREFIX}
+		${PREFIX}/bin
 	cp -r deps/cpy ${PREFIX}/deps
-	chmod ugo+rwx ${PREFIX}
-	chmod -R ugo+rw ${PREFIX}
+	chmod -R 755 ${PREFIX}
 	rm -f ${PREFIX}/Makefile
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ install:
 	cp -r deps/cpy ${PREFIX}/deps
 	chmod -R 755 ${PREFIX}
 	rm -f ${PREFIX}/Makefile
+	cp tools/ssdb.sh /etc/init.d/ssdb 
+	chmod +x /etc/init.d/ssdb.sh
 
 clean:
 	rm -f *.exe.stackdump

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ install:
 	mkdir -p ${PREFIX}/var_slave
 	# add by stefan_bo
 	mkdir -p ${PREFIX}/bin
-    mkdir -p ${PREFIX}/sbin
-    mkdir -p ${PREFIX}/conf
+    	mkdir -p ${PREFIX}/sbin
+    	mkdir -p ${PREFIX}/conf
 	cp ssdb-server ${PREFIX}/sbin
 	cp ssdb.conf ssdb_slave.conf ${PREFIX}/conf
 	cp -r api ${PREFIX}

--- a/ssdb.conf
+++ b/ssdb.conf
@@ -2,8 +2,8 @@
 # MUST indent by TAB!
 
 # relative to path of this file, directory must exists
-work_dir = ./var
-pidfile = ./var/ssdb.pid
+work_dir = /usr/local/ssdb/var
+pidfile = /usr/local/ssdb/var/ssdb.pid
 
 server:
 	ip: 127.0.0.1

--- a/tools/ssdb-ins.sh
+++ b/tools/ssdb-ins.sh
@@ -23,7 +23,7 @@ dir=`dirname $config`
 pidfile=$dir/`cat $config | sed -n 's/pidfile[[:blank:]]*=[[:blank:]]//p' | sed -n 's/^\.\///p'`
 
 start(){
-	${ssdb_root}/ssdb-server -d ${config}
+	${ssdb_root}/sbin/ssdb-server -d ${config}
 	if [ $? = "0" ]; then
 		echo "ssdb started."
 	else

--- a/tools/ssdb.sh
+++ b/tools/ssdb.sh
@@ -1,31 +1,84 @@
 #!/bin/bash
-# this script is used to start/stop ssdb-server instances on
-# system start/stop
-# put this script into /etc/init.d directory
+# 
+# ssdb - this script starts and stops the ssdb-server instances
+# 
+# chkconfig: - 85 15
+# description: SSDB is an NoSQL server 
+# processname: ssdb-server
+# config: /usr/local/ssdb/conf/ssdb.conf
+# pidfile: /usr/local/ssdb/var/ssdb.pid
 
-ssdb_root=/usr/local/ssdb
+ulimit -SHn 102400
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+# Check that networking is up.
+[ "$NETWORKING" = "no" ] && exit 0
+
+ssdb_daemon="/usr/local/ssdb/sbin/ssdb-server"
+ssdb_root="/usr/local/ssdb"
+prog=$(basename $ssdb_daemon)
+
 # each config file for one instance
 # configs="/data/ssdb_data/test/ssdb.conf /data/ssdb_data/test2/ssdb.conf"
-configs="/data/ssdb_data/test/ssdb.conf"
+configs="${ssdb_root}/conf/ssdb.conf"
+
+pidfile="${ssdb_root}/var/ssdb.pid"
+
+start() {
+    [ -x ${ssdb_daemon} ] || exit 5
+    [ -f ${configs} ] || exit 6
+    echo -n $"Starting $prog: "
+    daemon ${ssdb_daemon} -d ${configs}
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $pidfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $prog: "
+    killproc $prog -QUIT
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $pidfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+rh_status() {
+    status $prog
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
 
 case "$1" in
-	'start')
-		for conf in $configs; do
-			$ssdb_root/ssdb-ins.sh start $conf
-		done
-		;;
-	'stop')
-		for conf in $configs; do
-			$ssdb_root/ssdb-ins.sh stop $conf
-		done
-		;;
-	'restart')
-		for conf in $configs; do
-			$ssdb_root/ssdb-ins.sh restart $conf
-		done
-		;;
-	*)
-		echo "Usage: $0 {start|stop|restart}"
-		exit 1
-	;;
+    start)
+        rh_status_q && exit 0
+        $1
+    ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+    ;;
+    restart)
+        $1
+    ;;
+    status)
+        rh_status
+    ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart}"
+        exit 2
 esac


### PR DESCRIPTION
1. 重写ssdb.sh启动脚本 避免使用2个脚本控制服务启动停止  可以加入chkconfig 自动启动
2. 修改makefile 更改目录结构 配置 脚本分组存放
3. 修改makefile 将启动脚本自动存到/etc/init.d/下 