### PR TITLE
增加qsize_max支持

### DIFF
--- a/src/proc_queue.cpp
+++ b/src/proc_queue.cpp
@@ -75,6 +75,18 @@ int proc_qpush_func(Server *serv, Link *link, const Request &req, Response *resp
 				resp->push_back("error");
 				return 0;
 			}
+			if(serv->ssdb->qsize_max > 0 && size > serv->ssdb->qsize_max){
+				int64_t pop_count = size - serv->ssdb->qsize_max;
+				for(int64_t i = 0; i < pop_count; i++) {
+					std::string item;
+					if(front_or_back == QFRONT){
+						serv->ssdb->qpop_back(req[1], &item);
+					}else{
+						serv->ssdb->qpop_front(req[1], &item);
+					}
+					size = size - 1;
+				}
+			}
 		}
 		
 		char buf[20];

--- a/src/ssdb.cpp
+++ b/src/ssdb.cpp
@@ -54,7 +54,7 @@ SSDB* SSDB::open(const Config &conf, const std::string &base_dir){
 	int64_t qsize_max_num = -1;
 	
 	if (!qsize_max_str.empty()) {
-		qsize_max_num = _atoi64(qsize_max_str.c_str());
+		qsize_max_num = atoll(qsize_max_str.c_str());
 	}
 	
 	if (qsize_max_num <= 0){

--- a/src/ssdb.cpp
+++ b/src/ssdb.cpp
@@ -50,6 +50,16 @@ SSDB* SSDB::open(const Config &conf, const std::string &base_dir){
 	std::string compression = conf.get_str("leveldb.compression");
 	std::string binlog_onoff = conf.get_str("replication.binlog");
 	int sync_speed = conf.get_num("replication.sync_speed");
+	std::string qsize_max_str = conf.get_str("server.qsize_max");
+	int64_t qsize_max_num = -1;
+	
+	if (!qsize_max_str.empty()) {
+		qsize_max_num = _atoi64(qsize_max_str.c_str());
+	}
+	
+	if (qsize_max_num <= 0){
+		qsize_max_num = -1;
+	}
 
 	strtolower(&compression);
 	if(compression != "yes"){
@@ -82,6 +92,7 @@ SSDB* SSDB::open(const Config &conf, const std::string &base_dir){
 
 	SSDB *ssdb = new SSDB();
 	//
+	ssdb->qsize_max = qsize_max_num;
 	ssdb->options.create_if_missing = true;
 	ssdb->options.filter_policy = leveldb::NewBloomFilterPolicy(10);
 	ssdb->options.block_cache = leveldb::NewLRUCache(cache_size * 1048576);

--- a/src/ssdb.h
+++ b/src/ssdb.h
@@ -116,6 +116,7 @@ public:
 	int zrlist(const Bytes &name_s, const Bytes &name_e, uint64_t limit,
 			std::vector<std::string> *list) const;
 	
+	int64_t qsize_max;
 	int64_t qsize(const Bytes &name);
 	// @return 0: empty queue, 1: item peeked, -1: error
 	int qfront(const Bytes &name, std::string *item);


### PR DESCRIPTION
增加qsize_max支持, 如果配置文件中qsize_max>0，则队列长度保持在这个值，从另外一端pop出去