### PR TITLE
Modified the recv function for 5x faster performance with big responses

### DIFF
--- a/api/php/large-performance-test.php
+++ b/api/php/large-performance-test.php
@@ -1,0 +1,35 @@
+<?php
+
+	require_once('SSDB.php');
+
+	$db = new SimpleSSDB('127.0.0.1', 8888);
+
+	// load hash. Comment out on second run for faster test times
+	for($i=0;$i<100000;$i++){
+		if ($i > 0 && ($i % 10000) == 0)
+			echo "Loaded $i entries...\n";
+
+		$val = $i;
+
+		// Test for null values too
+		switch(rand(0,5)){
+			case 0:
+				$val = null;
+				break;
+			case 1:
+				$val = "\0";
+				break;
+			case 2:
+				$val = "";
+				break;
+			default:
+				$val = $i;
+		}
+		$db->hSet('large-response-test-hash', "This is a hash key $i", $val);
+	}
+
+	$keys = count($db->hkeys('large-response-test-hash', '', '', 1000000000));
+	echo "There are $keys keys in the response\n";
+
+	// $db->hClear('large-response-test-hash');
+


### PR DESCRIPTION
Hello there!

I made some optimizations for the recv function. It now performs much faster with big responses.

Original Version
$ time php large-response-test.php
There are 100000 keys in the response

real    0m13.201s
user    0m0.956s
sys 0m12.145s

New version
$ time php large-response-test.php
There are 100000 keys in the response

real    0m2.269s
user    0m0.080s
sys 0m2.100s
