### PR TITLE
add Dockerfile for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu
+MAINTAINER wendal "wendal1985@gmail.com"
+
+# Set the env variable DEBIAN_FRONTEND to noninteractive
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get install -y --force-yes git make gcc g++ && apt-get clean && \
+  git clone --depth 1 https://github.com/ideawu/ssdb.git ssdb && \
+  cd ssdb && make && make install && cp ssdb-server /usr/bin && \
+  apt-get remove -y --force-yes git make gcc g++ && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+  cp ssdb.conf /etc && cd .. && yes | rm -r ssdb
+
+RUN mkdir -p /var/lib/ssdb && \
+  sed \
+    -e 's@home.*@home /var/lib@' \
+    -e 's/loglevel.*/loglevel info/' \
+    -e 's@work_dir = .*@work_dir = /var/lib/ssdb@' \
+    -e 's@pidfile = .*@pidfile = /run/ssdb.pid@' \
+    -e 's@level:.*@level: info@' \
+    -e 's@ip:.*@ip: 0.0.0.0@' \
+    -i /etc/ssdb.conf
+
+
+ENV TZ Asia/Shanghai
+EXPOSE 8888
+VOLUME /var/lib/ssdb
+ENTRYPOINT /usr/bin/ssdb-server /etc/ssdb.conf


### PR DESCRIPTION
供docker自动构建所需的Dockerfile文件. 当前已经部署为

```
docker pull wendal/ssdb
```

非linux用户可以使用boot2docker来启动docker, 无需再自行编译ssdb, 而且性能比windows版的ssdb要好(测试用途啦).

启动代码:
```
docker run -p 8888:8888 -v /var/lib/ssdb:/var/lib/ssdb -t -i wendal/ssdb
```

建议@ideawu登陆到docker官网建立账户发布官方镜像