### PR TITLE
slave只同步特定前缀的key

### DIFF
--- a/src/backend_sync.h
+++ b/src/backend_sync.h
@@ -54,6 +54,7 @@ struct BackendSync::Client{
 	std::string last_key;
 	const BackendSync *backend;
 	bool is_mirror;
+    std::vector<std::string> prefix_list;
 	
 	Iterator *iter;
 
@@ -66,6 +67,7 @@ struct BackendSync::Client{
 	int sync(BinlogQueue *logs);
 
 	std::string stats();
+    bool match_prefix(const Binlog &log);
 };
 
 #endif

--- a/src/serv.cpp
+++ b/src/serv.cpp
@@ -270,9 +270,14 @@ SSDBServer::SSDBServer(SSDB *ssdb, SSDB *meta, const Config &conf, NetworkServer
 				}
 				
 				std::string id = c->get_str("id");
+
+                std::string prefix = c->get_str("prefix");
+                if (prefix.empty() ) {
+                    prefix = "*";
+                }
 				
-				log_info("slaveof: %s:%d, type: %s", ip.c_str(), port, type.c_str());
-				Slave *slave = new Slave(ssdb, meta, ip.c_str(), port, is_mirror);
+				log_info("slaveof: %s:%d, type: %s, prefix: %s", ip.c_str(), port, type.c_str(), prefix.c_str());
+				Slave *slave = new Slave(ssdb, meta, ip.c_str(), port, is_mirror, prefix.c_str());
 				if(!id.empty()){
 					slave->set_id(id);
 				}

--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -8,7 +8,7 @@ found in the LICENSE file.
 #include "slave.h"
 #include "include.h"
 
-Slave::Slave(SSDB *ssdb, SSDB *meta, const char *ip, int port, bool is_mirror){
+Slave::Slave(SSDB *ssdb, SSDB *meta, const char *ip, int port, bool is_mirror, const char *prefix){
 	thread_quit = false;
 	this->ssdb = ssdb;
 	this->meta = meta;
@@ -21,6 +21,8 @@ Slave::Slave(SSDB *ssdb, SSDB *meta, const char *ip, int port, bool is_mirror){
 	}else{
 		this->log_type = BinlogType::SYNC;
 	}
+
+    this->prefix = (prefix == NULL) ? "*" : prefix;
 	
 	{
 		char buf[128];
@@ -184,7 +186,7 @@ int Slave::connect(){
 				}
 			}
 			
-			link->send("sync140", str(this->last_seq), this->last_key, type);
+			link->send("sync140", str(this->last_seq), this->last_key, type, this->prefix);
 			if(link->flush() == -1){
 				log_error("[%s] network error", this->id_.c_str());
 				delete link;

--- a/src/slave.h
+++ b/src/slave.h
@@ -31,6 +31,8 @@ private:
 	bool is_mirror;
 	char log_type;
 
+    std::string prefix;
+
 	static const int DISCONNECTED = 0;
 	static const int INIT = 1;
 	static const int COPY = 2;
@@ -59,7 +61,7 @@ private:
 	}
 public:
 	std::string auth;
-	Slave(SSDB *ssdb, SSDB *meta, const char *ip, int port, bool is_mirror=false);
+	Slave(SSDB *ssdb, SSDB *meta, const char *ip, int port, bool is_mirror=false, const char* prefix = NULL);
 	~Slave();
 	void start();
 	void stop();

--- a/src/ssdb/binlog.h
+++ b/src/ssdb/binlog.h
@@ -32,6 +32,7 @@ public:
 	char type() const;
 	char cmd() const;
 	const Bytes key() const;
+    std::string user_key() const;
 
 	const char* data() const{
 		return buf.data();

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -15,7 +15,7 @@ found in the LICENSE file.
 #include <inttypes.h>
 #include <string>
 #include <algorithm>
-
+#include <vector>
 
 inline static
 int is_empty_str(const char *str){
@@ -418,5 +418,21 @@ int bitcount(const char *p, int size){
 	}
 #endif
 
+static inline
+std::vector<std::string> string_split(const char *str, char split_char) {
+    std::vector<std::string> vec;
+    const char *begin = str;
+    const char *p = str;
+    for (; p && *p; ++p) {
+        if (*p == split_char) {
+            vec.push_back(std::string(begin, p - begin));
+            begin = p + 1;
+        }
+    }
+
+    vec.push_back(std::string(begin, p - begin) );
+
+    return vec;
+}
 
 #endif

--- a/ssdb.conf
+++ b/ssdb.conf
@@ -30,6 +30,8 @@ replication:
 		#type: sync
 		#ip: 127.0.0.1
 		#port: 8889
+		# sync keys with specifiled prefix *|prefix0,prefix1,prefix2
+		#prefix: *
 
 logger:
 	level: debug


### PR DESCRIPTION
slaveof配置中, 增加prefix列表配置项.
kv: key匹配指定前缀.
hash, zset, queue: name匹配指定前缀

应用场景主要是在线分库.  