### PR TITLE
线程detach, 防止资源泄漏

### DIFF
--- a/src/backend_dump.cpp
+++ b/src/backend_dump.cpp
@@ -30,7 +30,7 @@ void BackendDump::proc(const Link *link){
 }
 
 void* BackendDump::_run_thread(void *arg){
-        pthread_detach(pthread_self());
+	pthread_detach(pthread_self());
 	struct run_arg *p = (struct run_arg*)arg;
 	const BackendDump *backend = p->backend;
 	Link *link = (Link *)p->link;

--- a/src/backend_dump.cpp
+++ b/src/backend_dump.cpp
@@ -30,6 +30,7 @@ void BackendDump::proc(const Link *link){
 }
 
 void* BackendDump::_run_thread(void *arg){
+        pthread_detach(pthread_self());
 	struct run_arg *p = (struct run_arg*)arg;
 	const BackendDump *backend = p->backend;
 	Link *link = (Link *)p->link;

--- a/src/backend_sync.cpp
+++ b/src/backend_sync.cpp
@@ -65,7 +65,7 @@ void BackendSync::proc(const Link *link){
 }
 
 void* BackendSync::_run_thread(void *arg){
-       pthread_detach(pthread_self());
+        pthread_detach(pthread_self());
 	struct run_arg *p = (struct run_arg*)arg;
 	BackendSync *backend = (BackendSync *)p->backend;
 	Link *link = (Link *)p->link;

--- a/src/backend_sync.cpp
+++ b/src/backend_sync.cpp
@@ -65,7 +65,7 @@ void BackendSync::proc(const Link *link){
 }
 
 void* BackendSync::_run_thread(void *arg){
-        pthread_detach(pthread_self());
+	pthread_detach(pthread_self());
 	struct run_arg *p = (struct run_arg*)arg;
 	BackendSync *backend = (BackendSync *)p->backend;
 	Link *link = (Link *)p->link;

--- a/src/backend_sync.cpp
+++ b/src/backend_sync.cpp
@@ -65,6 +65,7 @@ void BackendSync::proc(const Link *link){
 }
 
 void* BackendSync::_run_thread(void *arg){
+       pthread_detach(pthread_self());
 	struct run_arg *p = (struct run_arg*)arg;
 	BackendSync *backend = (BackendSync *)p->backend;
 	Link *link = (Link *)p->link;


### PR DESCRIPTION
Either pthread_join() or pthread_detach() should be called for each thread that an application creates, so that system resources for the thread can be released.