### PR TITLE
bug-fix, use wrong data when export queue structure

### DIFF
--- a/tools/ssdb_cli/exporter.cpy
+++ b/tools/ssdb_cli/exporter.cpy
@@ -150,14 +150,14 @@ function run(link, args){
 	scan.name = ls.key;
 	while(scan.next()){
 		show_progress();
-		write_line(['qpush', ls.key, scan.key]);
+		write_line(['qpush', ls.key, scan.val]);
 	}
 	while(ls.next()){
 		scan = new SSDB_queue_scan(link);
 		scan.name = ls.key;
 		while(scan.next()){
 			show_progress();
-			write_line(['qpush', ls.key, scan.key]);
+			write_line(['qpush', ls.key, scan.val]);
 		}
 	}
 	


### PR DESCRIPTION
in exporter.cpy
``` c
write_line(['qpush'], ls.key, scan.key]);
```
but exactly scan.key means "offset", not the queue item value
in util.cpy
```c
this.key = this.offset;
this.val = this.index.pop(0);
```
