### PR TITLE
增加 hsetnx 命令

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@
 		- The slave will flush db when receive copy_begin(2015-07-28)
 	* Incompatible changes:
 		- Will not support db size for redis clients(2015-08-07)
+	* Bug fixes:
+		- Fix Jedis zadd() score in scientific notation(2015-10-22)
 * 1.9.1
 	* Incompatible changes:
 		- zrank/zrrank return not_found(prev is error) if member not exists(2015-07-16)

--- a/src/net/link_redis.cpp
+++ b/src/net/link_redis.cpp
@@ -172,7 +172,8 @@ int RedisLink::convert_req(){
 			recv_string.push_back(recv_bytes[1].String());
 			for(int i=2; i<=recv_bytes.size()-2; i+=2){
 				recv_string.push_back(recv_bytes[i+1].String());
-				recv_string.push_back(recv_bytes[i].String());
+				int64_t score = (int64_t)recv_bytes[i].Double();
+				recv_string.push_back(str(score));
 			}
 		}
 		return 0;

--- a/src/net/proc.cpp
+++ b/src/net/proc.cpp
@@ -36,8 +36,9 @@ void ProcMap::set_proc(const std::string &c, const char *sflags, proc_t proc){
 			case 'r':
 				cmd->flags |= Command::FLAG_READ;
 				break;
-			case 'w':
+			case 'w': // w 必须和 t 同时出现, 因为某些写操作依赖单线程
 				cmd->flags |= Command::FLAG_WRITE;
+				cmd->flags |= Command::FLAG_THREAD;
 				break;
 			case 'b':
 				cmd->flags |= Command::FLAG_BACKEND;

--- a/src/net/server.cpp
+++ b/src/net/server.cpp
@@ -19,7 +19,7 @@ static DEF_PROC(auth);
 #define TICK_INTERVAL          100 // ms
 #define STATUS_REPORT_TICKS    (300 * 1000/TICK_INTERVAL) // second
 static const int READER_THREADS = 10;
-static const int WRITER_THREADS = 1;
+static const int WRITER_THREADS = 1;  // 必须为1, 因为某些写操作依赖单线程
 
 volatile bool quit = false;
 volatile uint32_t g_ticks = 0;


### PR DESCRIPTION
 hashmap 应增加 KV 类似的 setnx 命令，用于线程安全地设置 hincr 命令 非0的初始值。