### PR TITLE
fix ssdb-cli startup error while runing as symbol link

### DIFF
--- a/tools/ssdb-cli
+++ b/tools/ssdb-cli
@@ -1,5 +1,8 @@
 #!/bin/sh
-DIR=`dirname $0`
+SCRIPT=`readlink -f "$0"`
+[ -z "$SCRIPT" ] && SCRIPT=$0
+DIR=`dirname $SCRIPT`
+
 
 if [ -e $DIR/../deps/cpy/cpy ]; then
 	CPY=$DIR/../deps/cpy/cpy


### PR DESCRIPTION
If ssdb-cli was linked to another location(e.g. `/usr/local/ssdb/ssdb-cli`), it cannot startup:

```
 # ssdb-cli 
 /usr/local/sbin/ssdb-cli: 12: /usr/local/sbin/deps/cpy/cpy: not found
```

This is the fix.