### PR TITLE
binlog clean thread works more active

### DIFF
--- a/src/ssdb/binlog.cpp
+++ b/src/ssdb/binlog.cpp
@@ -354,10 +354,10 @@ void* BinlogQueue::log_clean_thread_func(void *arg){
 		if(!logs->db){
 			break;
 		}
-		usleep(100 * 1000);
 		assert(logs->last_seq >= logs->min_seq);
 
-		if(logs->last_seq - logs->min_seq < logs->capacity * 1.1){
+		if(logs->last_seq - logs->min_seq < logs->capacity + 1000){
+			usleep(50 * 1000);
 			continue;
 		}
 		


### PR DESCRIPTION
如 https://github.com/ideawu/ssdb/issues/867 中所讨论的，这个PR是为了增加log_clean线程的活跃度，减少每次清理的量，从而消除log_clean线程工作时带来的性能问题。