### PR TITLE
Update slave.cpp

### DIFF
--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -131,7 +131,7 @@ void Slave::migrate_old_status(){
 }
 
 std::string Slave::status_key(){
-	static std::string key;
+	std::string key;
 	if(key.empty()){
 		key = "slave.status." + this->id_;
 	}


### PR DESCRIPTION
从库同步多个主库的时候，status_key函数的key用了static。会导致只会保存和修改第一个主库的同步状态信息，同步多主库会出异常，建议去掉static修改。