### PR TITLE
binlogs->begin() 这句还需不需要？

### DIFF
--- a/src/ssdb/t_kv.cpp
+++ b/src/ssdb/t_kv.cpp
@@ -117,7 +117,6 @@ int SSDBImpl::del(const Bytes &key, char log_type){
 	Transaction trans(binlogs);
 
 	std::string buf = encode_kv_key(key);
-	binlogs->begin();
 	binlogs->Delete(buf);
 	binlogs->add_log(log_type, BinlogCommand::KDEL, buf);
 	leveldb::Status s = binlogs->commit();


### PR DESCRIPTION
我看Transaction对象自动会开始binlog，还要显式地再开始一下吗？