### PR TITLE
Update cpy

### DIFF
--- a/deps/cpy/cpy
+++ b/deps/cpy/cpy
@@ -2,9 +2,9 @@
 
 DIR=`dirname $0`
 
-which python2.7
+which python2.7 > /dev/null
 [ $? -eq 0 ] && { python2.7 $DIR/cpy.py $@; exit 0;}
-which python2
+which python2 > /dev/null
 [ $? -eq 0 ] && { python2 $DIR/cpy.py $@; exit 0;}
 
 python $DIR/cpy.py $@

--- a/deps/cpy/cpy
+++ b/deps/cpy/cpy
@@ -1,4 +1,10 @@
 #!/bin/sh
 
 DIR=`dirname $0`
+
+which python2.7
+[ $? -eq 0 ] && { python2.7 $DIR/cpy.py $@; exit 0;}
+which python2
+[ $? -eq 0 ] && { python2 $DIR/cpy.py $@; exit 0;}
+
 python $DIR/cpy.py $@


### PR DESCRIPTION
优先选用python2.7，如果不存在则选择系统默认python，现在很多Linux机器大多默认已经采用3.5.x，加个判断更友好吧。