### PR TITLE
修改可能会出现数据不一致的情况

### DIFF
--- a/src/backend_sync.cpp
+++ b/src/backend_sync.cpp
@@ -91,6 +91,12 @@ void* BackendSync::_run_thread(void *arg){
 #define TICK_INTERVAL_MS	300
 #define NOOP_IDLES			(3000/TICK_INTERVAL_MS)
 
+	const std::vector<Bytes> *req = NULL;
+	Fdevents backsync_select;
+	const Fdevents::events_t *backsync_events = NULL;
+	backsync_select.set(client.link->fd(),FDEVENT_IN,0,NULL);
+#define RECEIVE_SEQ_MS 5000
+
 	int idle = 0;
 	while(!backend->thread_quit){
 		// TODO: test
@@ -127,6 +133,12 @@ void* BackendSync::_run_thread(void *arg){
 			log_info("%s:%d fd: %d, send error: %s", link->remote_ip, link->remote_port, link->fd(), strerror(errno));
 			break;
 		}
+
+		//wait to receive seq only if expect_rec_seq > last_seq
+		if(client.status == Client::SYNC && client.expect_rec_seq > client.last_seq){
+			//log_debug("run_thread() wait for, client.expect_rec_seq=%"PRIu64 " > client.last_seq=%"PRIu64, client.expect_rec_seq,client.last_seq);
+			client.receive_seq(RECEIVE_SEQ_MS,backsync_select,backsync_events,req);
+		}		
 		if(backend->sync_speed > 0){
 			float data_size_mb = link->output->size() / 1024.0 / 1024.0;
 			usleep((data_size_mb / backend->sync_speed) * 1000 * 1000);
@@ -134,6 +146,7 @@ void* BackendSync::_run_thread(void *arg){
 	}
 
 	log_info("Sync Client quit, %s:%d fd: %d, delete link", link->remote_ip, link->remote_port, link->fd());
+	backsync_select.del(link->fd());
 	delete link;
 
 	Locking l(&backend->mutex);
@@ -153,6 +166,7 @@ BackendSync::Client::Client(const BackendSync *backend){
 	last_key = "";
 	is_mirror = false;
 	iter = NULL;
+	expect_rec_seq = 0;
 }
 
 BackendSync::Client::~Client(){
@@ -258,6 +272,7 @@ void BackendSync::Client::reset(){
 	this->status = Client::COPY;
 	this->last_seq = 0;
 	this->last_key = "";
+	this->expect_rec_seq = 0;
 
 	Binlog log(this->last_seq, BinlogType::COPY, BinlogCommand::BEGIN, "");
 	log_trace("fd: %d, %s", link->fd(), log.dumps().c_str());
@@ -396,10 +411,13 @@ int BackendSync::Client::sync(BinlogQueue *logs){
 		}
 	
 		// update last_seq
-		this->last_seq = log.seq();
+		if(this->status != Client::SYNC){
+			this->last_seq = log.seq();
+		}
 
 		char type = log.type();
 		if(type == BinlogType::MIRROR && this->is_mirror){
+			this->last_seq = log.seq(); //update last_seq
 			if(this->last_seq - this->last_noop_seq >= 1000){
 				this->noop();
 				return 1;
@@ -440,5 +458,71 @@ int BackendSync::Client::sync(BinlogQueue *logs){
 			link->send(log.repr());
 			break;
 	}
+	if(this->status == Client::SYNC){
+		this->expect_rec_seq = log.seq();
+		//log_debug("client::sync() set expect_rec_seq=%" PRIu64 ", link->fd: %d, %s", expect_rec_seq,link->fd(), log.dumps().c_str());
+	}
 	return 1;
 }
+
+/*
+* receive seq from slave, and call update_client_seq to update client.last_seq.
+* note:this should be called only when client.status is SYNC and client.except_rec_seq is more than client.last_seq
+*/
+int BackendSync::Client::receive_seq(int wait_ms,Fdevents &bc_select,const Fdevents::events_t *bc_events,const std::vector<Bytes> *req){
+
+	bc_events= bc_select.wait(wait_ms);
+	if(bc_events== NULL){//shi
+		log_error("receive_seq() backsync_events.wait error: %s", strerror(errno)); 		
+	}
+	if(bc_events->empty()){//shi
+		return 0;
+	}
+	if(link->read() <= 0){
+		log_error("receive_seq() fd=%d link.read error: %s", link->fd(),strerror(errno));
+		return -1;
+	}
+	//log_debug("receive_seq() fd=%d link.read OK", link->fd());
+	while(1){
+		req = link->recv();
+		if(req == NULL){
+			log_error("receive_seq() fd=%d link.recv error: %s", link->fd(),strerror(errno));
+			break;
+		}else if(req->empty()){
+			//log_debug("receive_seq() fd=%d link.recv req empty", link->fd());
+			break;
+		}else{
+			this->update_client_seq(*req);
+		}
+	}
+	return 1;
+
+}
+
+int BackendSync::Client::update_client_seq(const std::vector<Bytes> &req){
+	Binlog log;
+	if(log.load(req[0]) == -1){
+		log_error("update_client_seq() BackendSync::Client::update_client_seq invalid binlog!");
+		return -1;
+	}
+	switch(log.type()){
+		case BinlogType::UPDATE_SEQ:
+			break;
+		default:
+			return 0;	
+	}
+	uint64_t seq = log.seq();
+	if(req.size() >= 2){
+		log_debug("update_client_seq() %s [%d]",log.dumps().c_str(), req[1].size());
+	}else{
+		log_debug("update_client_seq() %s",log.dumps().c_str());
+	}	
+	if(this->last_seq + 1 <= seq){
+		//log_debug("update_client_seq() BackendSync::Client::update_client_seq OK for this->last_seq=%"PRIu64 " to log.seq=%"PRIu64, this->last_seq,seq);
+		this->last_seq = seq;
+		return 1;
+	}
+	//log_debug("update_client_seq() BackendSync::Client::update_client_seq fail for this->last_seq=%"PRIu64 " + 1 > log.seq=%"PRIu64, this->last_seq,seq);
+	return 0;
+}
+

--- a/src/backend_sync.h
+++ b/src/backend_sync.h
@@ -16,6 +16,9 @@ found in the LICENSE file.
 #include "net/link.h"
 #include "util/thread.h"
 
+#include "net/fde.h"
+
+
 class BackendSync{
 private:
 	struct Client;
@@ -54,6 +57,7 @@ struct BackendSync::Client{
 	std::string last_key;
 	const BackendSync *backend;
 	bool is_mirror;
+	uint64_t expect_rec_seq; //(used for SYNC states, not be used in COPY) record the seq that has be sent to slave
 	
 	Iterator *iter;
 
@@ -65,6 +69,8 @@ struct BackendSync::Client{
 	int copy();
 	int sync(BinlogQueue *logs);
 	void out_of_sync();
+	int update_client_seq(const std::vector<Bytes> &req);
+	int receive_seq(int wait_ms,Fdevents &bc_select,const Fdevents::events_t *bc_events,const std::vector<Bytes> *req);
 
 	std::string stats();
 };

--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -363,7 +363,6 @@ int Slave::proc_copy(const Binlog &log, const std::vector<Bytes> &req){
 				log_info("copy_count: %" PRIu64 ", last_seq: %" PRIu64 ", seq: %" PRIu64 "",
 					copy_count, this->last_seq, log.seq());
 			}
-			usleep(1000);
 			return proc_sync(log, req);
 			break;
 	}

--- a/src/slave.cpp
+++ b/src/slave.cpp
@@ -310,7 +310,8 @@ int Slave::proc(const std::vector<Bytes> &req){
 		}
 		case BinlogType::SYNC:
 		case BinlogType::MIRROR:{
-			status = SYNC;
+			//when master and slave is in copy state,slave may recieve log.type = SYNC (set key to master, and key < client.last_key)
+			//status = SYNC;
 			if(++sync_count % 1000 == 1){
 				log_info("sync_count: %" PRIu64 ", last_seq: %" PRIu64 ", seq: %" PRIu64 "",
 					sync_count, this->last_seq, log.seq());
@@ -362,6 +363,7 @@ int Slave::proc_copy(const Binlog &log, const std::vector<Bytes> &req){
 				log_info("copy_count: %" PRIu64 ", last_seq: %" PRIu64 ", seq: %" PRIu64 "",
 					copy_count, this->last_seq, log.seq());
 			}
+			usleep(1000);
 			return proc_sync(log, req);
 			break;
 	}
@@ -369,6 +371,15 @@ int Slave::proc_copy(const Binlog &log, const std::vector<Bytes> &req){
 }
 
 int Slave::proc_sync(const Binlog &log, const std::vector<Bytes> &req){
+	if(log.type() == BinlogType::SYNC && this->status == SYNC){
+		if(this->last_seq >= log.seq()){
+			//this seq was processed before, only send seq to master backend_sync thread
+			sync_count--;
+			this->update_master_seq();
+			return 0;
+		}
+	}
+
 	switch(log.cmd()){
 		case BinlogCommand::KSET:
 			{
@@ -517,6 +528,33 @@ int Slave::proc_sync(const Binlog &log, const std::vector<Bytes> &req){
 		this->last_key = log.key().String();
 	}
 	this->save_status();
+
+	if(log.type() == BinlogType::SYNC && this->status == SYNC){
+		this->update_master_seq();
+	}
+
 	return 0;
+}
+
+/*
+* note:this should be called only when log.type is SYNC and status is SYNC
+* send slave.last_seq to client.last_seq of the master's backsync thread
+*/
+int Slave::update_master_seq(){
+	uint64_t seq;
+	seq = this->last_seq;
+	Binlog noop(seq, BinlogType::UPDATE_SEQ, BinlogCommand::NONE, "");
+	//log_debug("update_master_seq() fd: %d, %s", link->fd(), noop.dumps().c_str());
+	link->send(noop.repr());
+	int len =link->flush();
+	if(len == -1){
+		log_error("%s:%d fd: %d, send error: %s", link->remote_ip, link->remote_port, link->fd(), strerror(errno));
+		return -1;
+	}else if(len == 0){
+		log_error("%s:%d fd: %d, for send len return 0, error: %s", link->remote_ip, link->remote_port, link->fd(), strerror(errno));
+		return -1;
+	}
+	//log_debug("update_master_seq() send seq to %s:%d fd: %d OK ,send len=%d", link->remote_ip, link->remote_port, link->fd(),len);
+	return len;
 }
 

--- a/src/slave.h
+++ b/src/slave.h
@@ -52,6 +52,7 @@ private:
 	int proc_noop(const Binlog &log, const std::vector<Bytes> &req);
 	int proc_copy(const Binlog &log, const std::vector<Bytes> &req);
 	int proc_sync(const Binlog &log, const std::vector<Bytes> &req);
+	int update_master_seq();
 
 	unsigned int connect_retry;
 	int connect();

--- a/src/ssdb/const.h
+++ b/src/ssdb/const.h
@@ -31,7 +31,7 @@ public:
 	static const char MIRROR	= 2;
 	static const char COPY		= 3;
 	static const char CTRL		= 4;
-	static const char UPDATE_SEQ= 5;
+	static const char UPDATE_SEQ	= 5;
 };
 
 class BinlogCommand{

--- a/src/ssdb/const.h
+++ b/src/ssdb/const.h
@@ -31,7 +31,7 @@ public:
 	static const char MIRROR	= 2;
 	static const char COPY		= 3;
 	static const char CTRL		= 4;
-	static const char UPDATE_SEQ = 5;
+	static const char UPDATE_SEQ= 5;
 };
 
 class BinlogCommand{

--- a/src/ssdb/const.h
+++ b/src/ssdb/const.h
@@ -31,6 +31,7 @@ public:
 	static const char MIRROR	= 2;
 	static const char COPY		= 3;
 	static const char CTRL		= 4;
+	static const char UPDATE_SEQ = 5;
 };
 
 class BinlogCommand{


### PR DESCRIPTION
因为原来的同步机制，slave的处理失败不能反馈；master端的client.last_seq已经增加，虽然slave的last_seq在当时没有更新，但是后面空闲时master发送的noop消息会把slave端的last_seq更新，所以slave端处理失败seq，即使是重启ssdb也得不到同步。这样导致的结果是会出现数据不一致。
修改：SYNC状态下，master的client.last_seq在接到slave的处理成功消息后才更新。