### PR TITLE
exit status on parse error

### DIFF
--- a/tools/ssdb_cli/nagios.cpy
+++ b/tools/ssdb_cli/nagios.cpy
@@ -48,6 +48,7 @@ function run(link, cli_args){
 		# - does total_calls is growing
 	}catch(Exception e){
 		sys.stderr.write(str(e) + '\n');
+		exit(2);
 	}
 	#sys.stderr.write('exit\n');
 	exit(0);


### PR DESCRIPTION
Parse would fail if the ssdb server is down - false exitcode(0) was returned.