### PR TITLE
Binary data to display as string escaped in ssdb-cli

### DIFF
--- a/api/python/SSDB.py
+++ b/api/python/SSDB.py
@@ -434,7 +434,7 @@ class SSDB(object):
 				pass
 				break
 			data = this.recv_buf[spos : epos]
-			ret.append(data)
+			ret.append(data.encode("string_escape"))
 			spos = epos
 			epos = this.recv_buf.find('\n', spos)
 


### PR DESCRIPTION
hi, all response data translated by string_escaped function.
So, you can copy it from the terminal, and import the data by import tool.