### PR TITLE
fix: log to stdout should not be rotated

### DIFF
--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -268,7 +268,7 @@ int Logger::logv(int level, const char *fmt, va_list ap){
 
 	stats.w_curr += len;
 	stats.w_total += len;
-	if(rotate_size_ > 0 && stats.w_curr > rotate_size_){
+	if(strcmp(this->filename, "stdout") != 0 && rotate_size_ > 0 && stats.w_curr > rotate_size_){
 		this->rotate();
 	}
 	if(this->mutex){


### PR DESCRIPTION
If ssdb config is set to write logs to `stdout` and the `rotate option is set`, it won't write logs after a certain amount of the logs are written (due to the rotation). 

So, when stdout is set as log output, it should not rotate the log file.