### PR TITLE
Ehancement: slaveof command to also accept mirror type

### DIFF
--- a/src/proc_sys.cpp
+++ b/src/proc_sys.cpp
@@ -235,42 +235,42 @@ int proc_sync140(NetworkServer *net, Link *link, const Request &req, Response *r
 
 // slaveof id host port [type last_seq last_key auth]
 int proc_slaveof(NetworkServer *net, Link *link, const Request &req, Response *resp){
-        SSDBServer *serv = (SSDBServer *)net->data;
-        CHECK_NUM_PARAMS(3);
+	SSDBServer *serv = (SSDBServer *)net->data;
+	CHECK_NUM_PARAMS(3);
 
-        std::string id = req[1].String();
-        std::string host = req[2].String();
-        int port = req[3].Int();
-        std::string auth;
-        uint64_t last_seq = 0;
-        std::string last_key;
-        bool type = false;
+	std::string id = req[1].String();
+	std::string host = req[2].String();
+	int port = req[3].Int();
+	std::string auth;
+	uint64_t last_seq = 0;
+	std::string last_key;
+	bool type = false;
 
-        log_info("start slaveof: %s:%d", host.c_str(), port);
-        log_info("    id: %s", id.c_str());
+	log_info("start slaveof: %s:%d", host.c_str(), port);
+	log_info("    id: %s", id.c_str());
 
-        // optional arguments
-        if(req.size() > 4 && !req[4].empty() && req[4] == "mirror"){
-                type = true;
-                log_info("    type: mirror");
-        } else {
-                log_info("    type: sync");
-        }
+	// optional arguments
+	if(req.size() > 4 && !req[4].empty() && req[4] == "mirror"){
+		type = true;
+		log_info("    type: mirror");
+	} else {
+		log_info("    type: sync");
+	}
 
-        if(req.size() > 5 && !req[5].empty()){
-                last_seq = req[5].Uint64();
-                log_info("    last_seq: %" PRIu64, last_seq);
-        }
+	if(req.size() > 5 && !req[5].empty()){
+		last_seq = req[5].Uint64();
+		log_info("    last_seq: %" PRIu64, last_seq);
+	}
 
-        if(req.size() > 6 && !req[6].empty()){
-                last_key = req[6].String();
-                log_info("    last_key: %s", hexmem(last_key.data(), last_key.size()).c_str());
-        }
+	if(req.size() > 6 && !req[6].empty()){
+		last_key = req[6].String();
+		log_info("    last_key: %s", hexmem(last_key.data(), last_key.size()).c_str());
+	}
 
-        if(req.size() > 7 && !req[7].empty()){
-                auth = req[7].String();
-                log_info("    auth: ***");
-        }
+	if(req.size() > 7 && !req[7].empty()){
+		auth = req[7].String();
+		log_info("    auth: ***");
+	}
 
         serv->slaveof(id, host, port, auth, last_seq, last_key, type, 0);
 

--- a/src/proc_sys.cpp
+++ b/src/proc_sys.cpp
@@ -233,35 +233,49 @@ int proc_sync140(NetworkServer *net, Link *link, const Request &req, Response *r
 	return PROC_BACKEND;
 }
 
-// slaveof id host port [auth last_seq last_key]
+// slaveof id host port [type last_seq last_key auth]
 int proc_slaveof(NetworkServer *net, Link *link, const Request &req, Response *resp){
-	SSDBServer *serv = (SSDBServer *)net->data;
-	CHECK_NUM_PARAMS(3);
-	
-	std::string id = req[1].String();
-	std::string host = req[2].String();
-	int port = req[3].Int();
-	std::string auth;
-	uint64_t last_seq = 0;
-	std::string last_key;
-	log_info("start slaveof: %s:%d, type: sync", host.c_str(), port);
-	if(req.size() > 4 && !req[4].empty()){
-		auth = req[4].String();
-		log_info("    auth: ***");
-	}
-	if(req.size() > 5 && !req[5].empty()){
-		last_seq = req[5].Uint64();
-		log_info("    last_seq: %" PRIu64, last_seq);
-	}
-	if(req.size() > 6 && !req[6].empty()){
-		last_key = req[6].String();
-		log_info("    last_key: %s", hexmem(last_key.data(), last_key.size()).c_str());
-	}
-	
-	serv->slaveof(id, host, port, auth, last_seq, last_key, false, 0);
+        SSDBServer *serv = (SSDBServer *)net->data;
+        CHECK_NUM_PARAMS(3);
 
-	resp->push_back("ok");
-	return 0;
+        std::string id = req[1].String();
+        std::string host = req[2].String();
+        int port = req[3].Int();
+        std::string auth;
+        uint64_t last_seq = 0;
+        std::string last_key;
+        bool type = false;
+
+        log_info("start slaveof: %s:%d", host.c_str(), port);
+        log_info("    id: %s", id.c_str());
+
+        // optional arguments
+        if(req.size() > 4 && !req[4].empty() && req[4] == "mirror"){
+                type = true;
+                log_info("    type: mirror");
+        } else {
+                log_info("    type: sync");
+        }
+
+        if(req.size() > 5 && !req[5].empty()){
+                last_seq = req[5].Uint64();
+                log_info("    last_seq: %" PRIu64, last_seq);
+        }
+
+        if(req.size() > 6 && !req[6].empty()){
+                last_key = req[6].String();
+                log_info("    last_key: %s", hexmem(last_key.data(), last_key.size()).c_str());
+        }
+
+        if(req.size() > 7 && !req[7].empty()){
+                auth = req[7].String();
+                log_info("    auth: ***");
+        }
+
+        serv->slaveof(id, host, port, auth, last_seq, last_key, type, 0);
+
+        resp->push_back("ok");
+        return 0;
 }
 
 int proc_clear_binlog(NetworkServer *net, Link *link, const Request &req, Response *resp){


### PR DESCRIPTION
slaveof now also accepts the type argument as an optional argument. Allowing mirror to be chosen:
For sync (master-slave):
```
slaveof sv_01 127.0.0.1 8888 ; or
slaveof sv_01 127.0.0.1 8888 sync
```

For mirror (master-master)
```
slaveof sv_01 127.0.0.1 8888 mirror
```

Next to this minor enhancements have been made: auth has been placed as the last argument to prevent users without authentication to not be able to use the last_seq or last_key.

Changes have been verified:
Compile succeeds
Tests succeed for the following commands:

```
slaveof sv_01 127.0.0.1 8888 ; creates replication in sync mode
slaveof sv_01 127.0.0.1 8888 sync ; creates replication in sync mode
slaveof sv_01 127.0.0.1 8888 0; creates replication in sync mode
slaveof sv_01 127.0.0.1 8888 mirror; creates replication in mirror mode
```