### PR TITLE
Security fix: do not make the whole tree world writable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ install:
 		${PREFIX}
 	cp -rf deps/cpy ${PREFIX}/deps
 	chmod 755 ${PREFIX}
-	chmod -R ugo+rw ${PREFIX}/*
 	rm -f ${PREFIX}/Makefile
 
 clean:


### PR DESCRIPTION
Security fix: do not make the whole tree world writable.
This includes the binaries that may be executed by root, allowing an easy local privilege escalation for anyone with access to the server.