### PR TITLE
Allow IPv6 loopback address ::1 as well.

### DIFF
--- a/src/net/server.cpp
+++ b/src/net/server.cpp
@@ -562,9 +562,11 @@ static int proc_auth(NetworkServer *net, Link *link, const Request &req, Respons
 }
 
 #define ENSURE_LOCALHOST() do{ \
-		if(strcmp(link->remote_ip, "127.0.0.1") != 0){ \
+		if(strcmp(link->remote_ip, "127.0.0.1") != 0 \
+			&& strcmp(link->remote_ip, "::1") != 0) \
+		{ \
 			resp->push_back("noauth"); \
-			resp->push_back("this command is only available from 127.0.0.1"); \
+			resp->push_back("this command is only available from localhost"); \
 			return 0; \
 		} \
 	}while(0)


### PR DESCRIPTION
Actually a more correct test for a loopback connection would be local_ip == remote_ip, but local_ip isn't exposed.  (In that case `ssdb-cli -h $(hostname)` would work as well.)