### PR TITLE
fix object leak

### DIFF
--- a/src/net/link.h
+++ b/src/net/link.h
@@ -61,6 +61,7 @@ class Link{
 
 		static Link* connect(const char *ip, int port);
 		static Link* listen(const char *ip, int port);
+		static Link* listen_unixsock(const char *unixsock_path);
 		Link* accept();
 
 		// read network data info buffer

--- a/src/net/server.h
+++ b/src/net/server.h
@@ -30,9 +30,10 @@ private:
 
 	//Config *conf;
 	Link *serv_link;
+	Link *unixsocket_serve_link;
 	Fdevents *fdes;
 
-	Link* accept_link();
+	Link* accept_link(Link* srv = NULL);
 	int proc_result(ProcJob *job, ready_list_t *ready_list);
 	int proc_client_event(const Fdevent *fde, ready_list_t *ready_list);
 
@@ -64,6 +65,7 @@ public:
 	// could be called only once
 	static NetworkServer* init(const char *conf_file, int num_readers=-1, int num_writers=-1);
 	static NetworkServer* init(const Config &conf, int num_readers=-1, int num_writers=-1);
+	static NetworkServer* init_sockets(const Config &conf, int num_readers=-1, int num_writers=-1);
 	void serve();
 };
 

--- a/src/ssdb/binlog.cpp
+++ b/src/ssdb/binlog.cpp
@@ -300,6 +300,7 @@ int BinlogQueue::find_min(Binlog *log) const{
 			}
 		}
 	}
+	delete it;
 	return ret;
 }
 

--- a/src/ssdb/binlog.cpp
+++ b/src/ssdb/binlog.cpp
@@ -406,6 +406,13 @@ int BinlogQueue::del_range(uint64_t start, uint64_t end){
 			return -1;
 		}
 	}
+
+	std::string range_min = encode_seq_key(0);
+	std::string range_delete_end = encode_seq_key(end);
+
+	leveldb::Slice smin(range_min);
+	leveldb::Slice smax(range_delete_end);
+	this->db->CompactRange(&smin,&smax);
 	return 0;
 }
 


### PR DESCRIPTION
1.9.7版本ssdb运行一段时间后leveldb会变得很大，重启可回复。怀疑是leveldb Version泄露，于是找到了这个迭代器泄露。