### PR TITLE
Store history in the user's homedir instead of a system-wide location.

### DIFF
--- a/tools/ssdb-cli.cpy
+++ b/tools/ssdb-cli.cpy
@@ -16,7 +16,7 @@ function save_cli_history(histfile){
 try{
 	import readline;
 	import atexit;
-	histfile = '/tmp/ssdb-cli.history';
+	histfile = os.path.expanduser('~/.ssdb-cli_history');
 	if(os.path.isfile(histfile)){
 		readline.read_history_file(histfile);
 	}


### PR DESCRIPTION
Otherwise only the first user that ran ssdb-cli could use history.
Also use the more common filename format `.toolname_history`.