### PR TITLE
update ssdb_slave.conf to clarify default slaveof.id

### DIFF
--- a/ssdb_slave.conf
+++ b/ssdb_slave.conf
@@ -16,7 +16,7 @@ replication:
 	sync_speed: -1
 	slaveof:
 		# to identify a master even if it moved(ip, port changed)
-		# if set to empty or not defined, ip:port will be used.
+		# if set to empty or not defined, "ip|port" will be used (e.g. "10.0.0.1|8888").
 		id: svc_1
 		# sync|mirror, default is sync
 		type: sync


### PR DESCRIPTION
per https://github.com/ideawu/ssdb/blob/master/src/slave.cpp#L28, the default id format is `ip|port`

It might be cleaner to change the source code, but due to backward compatibility concerns we probably shouldn't do so.