### PR TITLE
Fixed Auth Exception on multi -> qpush -> exec

### DIFF
--- a/api/php/SSDB.php
+++ b/api/php/SSDB.php
@@ -151,11 +151,27 @@ class SSDB
 	}
 	
 	private $async_auth_password = null;
+
+    function auth($password){
+        // If batching, send auth immediately before other commands
+        if ($this->batch_mode) {
+            // Temporarily break out of batch mode to send auth command
+            $this->batch_mode = false;
+            $this->batch_cmds = array();
+            $resp = $this->__call('auth', array($password));
+            $this->batch_mode = true;
+            return $resp === true || (is_object($resp) && $resp->ok());
+        }
+    
+        // Normal mode: send auth right away
+        return $this->__call('auth', array($password));
+    }
+
 	
-	function auth($password){
-		$this->async_auth_password = $password;
-		return null;
-	}
+	//function auth($password){
+	//	$this->async_auth_password = $password;
+	//	return null;
+	//}
 
 	function __call($cmd, $params=array()){
 		$cmd = strtolower($cmd);


### PR DESCRIPTION
multi -> qpush -> exec gives auth exception, this PR is a fix for the same, please run below test code to confirm before and after pull

```
<?php
require_once 'SSDB.php';

$ssdb = new SSDB('127.0.0.1', 8888);
$ssdb->auth('your_password'); // replace if needed

$ssdb->multi();
$ssdb->qpush_back('test_multi_queue', 'one');
$ssdb->qpush_back('test_multi_queue', 'two');
$ssdb->qpush_back('test_multi_queue', 'three');
$result = $ssdb->exec();

print_r($result);

$qsize = $ssdb->qsize('test_multi_queue');
echo "QSIZE: $qsize\n";
```
